### PR TITLE
Cross platform compatibility

### DIFF
--- a/config/home/.bin/streamMedia.sh
+++ b/config/home/.bin/streamMedia.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function playYT() {
 	URL_LIST=()


### PR DESCRIPTION
Some systems like FreeBSD put bash in /usr/local/bin/bash.
To make it work on Linux and BSD it is needed to have /usr/bin/env bash instead of /bin/bash